### PR TITLE
No more tagging @tercio unwantedly x)

### DIFF
--- a/db/users.json
+++ b/db/users.json
@@ -284,11 +284,6 @@
     "slack_user": "Caio",
     "github_user": "Caio-Batista"
   },
-  "UCKKG2KQ9": {
-    "id": "UCKKG2KQ9",
-    "slack_user": "tercio",
-    "github_user": "terciodemelo"
-  },
   "UCKLPE52M": {
     "id": "UCKLPE52M",
     "slack_user": "isaque",


### PR DESCRIPTION
I have way too many mentions :try_not_to_cry:, and I give them a lot
of priority. This disturbs my workflow everytime I merge something on
GitHub